### PR TITLE
Add backend linting workflow with mypy and ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint Backend
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  lint-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.4.15"
+          enable-cache: true
+      - run: uv run bash scripts/lint.sh
+        working-directory: src

--- a/.github/workflows/scripts/lint.sh
+++ b/.github/workflows/scripts/lint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+mypy app
+ruff check app
+ruff format app --check


### PR DESCRIPTION
Introduces a GitHub Actions workflow to lint the backend on push and pull requests to master. The workflow sets up Python 3.12, installs uv, and runs a shell script that checks type safety with mypy and code style/formatting with ruff.